### PR TITLE
added training datasets subsection

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,15 @@ social network, flow chart, mind map). It's also important for LLM or VLM to bui
 
 
 ## Datasets & Benchmarks
+### Core Training Datasets
+
+| Title | Introduction | Date | Code |
+| :----------------------------------------------------------- | :----------------------------------------------------------: | :--------: | :------------------------------------------------------: |
+| <br/>[SpatialLadder-26k: Spatial Reasoning QA Pairs](https://huggingface.co/datasets/hongxingli/SpatialLadder-26k ) | <img width="700" alt="image" src="imgs/SpatialLadder26k.png"> | 2025-08 | [HuggingFace](https://huggingface.co/datasets/hongxingli/SpatialLadder-26k ) |
+| <br/>[MMC4-Core: Multimodal C4 Corpus](https://github.com/allenai/mmc4 ) | <img width="700" alt="image" src="imgs/MMC4.png"> | 2023-06 | [GitHub](https://github.com/allenai/mmc4 ) |
+| <br/>[COYO-700M: High-Quality Image-Text Dataset](https://huggingface.co/datasets/kakaobrain/coyo-700m ) | <img width="700" alt="image" src="imgs/COYO.png"> | 2022-09 | [HuggingFace](https://huggingface.co/datasets/kakaobrain/coyo-700m ) |
+| <br/>[LAION-5B: A Large-scale Dataset for Vision-Language Pretraining](https://laion.ai/blog/laion-5b/ ) | <img width="700" alt="image" src="imgs/LAION5B.png"> | 2022-03 | [Website](https://laion.ai/blog/laion-5b/ ) |
+| <br/>[Visual Genome: Dense Visual Annotations](https://homes.cs.washington.edu/~ranjay/visualgenome/index.html ) | <img width="700" alt="image" src="imgs/VisualGenome.png"> | 2016-02 | [Website](https://homes.cs.washington.edu/~ranjay/visualgenome/index.html ) |
 ### Visual-based data
 | Title                                                        |                         Introduction                         |    Date    |                           Code                           |
 | :----------------------------------------------------------- | :----------------------------------------------------------: | :--------: | :------------------------------------------------------: |


### PR DESCRIPTION
This PR adds datasets used to train spatially aware VLMs: 

1. LAION-5B (5B pairs) - Diverse real-world scenes for spatial pretraining
2. MMC4-Core (101M sequences) - Interleaved image-text for contextual spatial relationships  
3. COYO-700M (700M pairs) - High-resolution images for detailed spatial understanding
4. SpatialLadder-26k (26k QA pairs) - Explicit spatial reasoning supervision
5. Visual Genome (5.4M annotations) - Object/relationship labels

Helps researchers identify data gaps for new spatial reasoning research.
All entries follow existing format with verified links as of Nov 2025.

Looking forward to feedback and happy to iterate!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Core Training Datasets subsection under Datasets & Benchmarks featuring five prominent datasets (SpatialLadder-26k, MMC4-Core, COYO-700M, LAION-5B, Visual Genome) with titles, descriptions, dates, and code references
  * Expanded Visual-based data section with comprehensive dataset catalog including spatial intelligence and visual tuning resources, each with complete metadata documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->